### PR TITLE
Fix intervention metric issues

### DIFF
--- a/configs/config.yaml
+++ b/configs/config.yaml
@@ -4,6 +4,7 @@ experiment_dir: './experiments/'  # Directory to potentially save the model to
 seed: 0 # Random seed
 workers: 2 # Number of workers for data loading
 save_model: False # Whether to save the model. Set to True for inspecting models post training [True, False]
+train_only: False # Whether to train the model only and exit before performing interventions [True, False]
 
 logging:
   project: 'SCBM' # Name of the wandb project

--- a/train.py
+++ b/train.py
@@ -288,6 +288,10 @@ def train(config):
         concept_names_graph=concept_names_graph,
     )
 
+    if config.train_only:
+        wandb.finish(quiet=True)
+        return None
+
     # Intervention curves
     print("\nPERFORMING INTERVENTIONS:\n")
     intervene(


### PR DESCRIPTION
Running train.py currently triggers a crash at the interventions. This commit adds some error checking and clamps values


```
PERFORMING INTERVENTIONS:

USING FOLLOWING POLICY: RandomSubsetInterventionPolicy
USING FOLLOWING STRATEGY: PercentileStrategy
Intervention on 0 concepts: target_loss: 1.337 prec_loss: 0.045 concepts_loss: 5.589 total_loss: 6.971 y_accuracy: 0.702 c_accuracy: 0.951 complete_c_accuracy: 0.471 target_jaccard: 0.541 concept_jaccard: 0.778 covariance_norm: 4.905 y_AUROC: 0.990 y_AUPR: 0.755 y_Brier: 0.437 y_ECE: 0.142 y_TL-ECE: 0.154 c_AUROC: 0.978 c_AUPR: 0.924 c_Brier: 0.037 c_ECE: 0.019 c_TL-ECE: 0.041

91it [00:04, 21.06it/s]
Error executing job with overrides: ['+model=SCBM', '+data=CUB']
Traceback (most recent call last):
  File "/mnt/c/Users/maxwb/Development/SCBM/train.py", line 306, in main
    train(config)
  File "/mnt/c/Users/maxwb/Development/SCBM/train.py", line 293, in train
    intervene(
  File "/mnt/c/Users/maxwb/Development/SCBM/utils/intervention.py", line 283, in intervene_scbm
    metrics_dict = metrics.compute(validation=True, config=config)
                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/maxwb/miniconda3/envs/scbm/lib/python3.11/site-packages/torchmetrics/metric.py", line 532, in wrapped_func
    value = compute(*args, **kwargs)
            ^^^^^^^^^^^^^^^^^^^^^^^^
  File "/mnt/c/Users/maxwb/Development/SCBM/utils/training.py", line 572, in compute
    c_metrics, _ = calc_concept_metrics(
                   ^^^^^^^^^^^^^^^^^^^^^
  File "/mnt/c/Users/maxwb/Development/SCBM/utils/metrics.py", line 192, in calc_concept_metrics
    ece_fct(
  File "/home/maxwb/miniconda3/envs/scbm/lib/python3.11/site-packages/torch/nn/modules/module.py", line 1751, in _wrapped_call_impl
    return self._call_impl(*args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/maxwb/miniconda3/envs/scbm/lib/python3.11/site-packages/torch/nn/modules/module.py", line 1762, in _call_impl
    return forward_call(*args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/maxwb/miniconda3/envs/scbm/lib/python3.11/site-packages/torchmetrics/metric.py", line 236, in forward
    self._forward_cache = self._forward_reduce_state_update(*args, **kwargs)
                          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/maxwb/miniconda3/envs/scbm/lib/python3.11/site-packages/torchmetrics/metric.py", line 303, in _forward_reduce_state_update
    batch_val = self.compute()
                ^^^^^^^^^^^^^^
  File "/home/maxwb/miniconda3/envs/scbm/lib/python3.11/site-packages/torchmetrics/metric.py", line 532, in wrapped_func
    value = compute(*args, **kwargs)
            ^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/maxwb/miniconda3/envs/scbm/lib/python3.11/site-packages/torchmetrics/classification/calibration_error.py", line 128, in compute
    return _ce_compute(confidences, accuracies, self.n_bins, norm=self.norm)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/maxwb/miniconda3/envs/scbm/lib/python3.11/site-packages/torchmetrics/functional/classification/calibration_error.py", line 90, in _ce_compute
    acc_bin, conf_bin, prop_bin = _binning_bucketize(confidences, accuracies, bin_boundaries)
                                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/maxwb/miniconda3/envs/scbm/lib/python3.11/site-packages/torchmetrics/functional/classification/calibration_error.py", line 48, in _binning_bucketize
    count_bin.scatter_add_(dim=0, index=indices, src=torch.ones_like(confidences))
RuntimeError: index -1 is out of bounds for dimension 0 with size 10

Set the environment variable HYDRA_FULL_ERROR=1 for a complete stack trace.
```