### PR TITLE
Vectorize implementation of compute concept loss for CBM model. Free speed up!

### DIFF
--- a/models/losses.py
+++ b/models/losses.py
@@ -81,19 +81,8 @@ class CBLoss(nn.Module):
         Returns:
             Tensor: Target loss, concept loss, and total loss.
         """
-
-        concepts_loss = 0
-
         assert torch.all((concepts_true == 0) | (concepts_true == 1))
-
-        for concept_idx in range(concepts_true.shape[1]):
-            c_loss = F.binary_cross_entropy(
-                concepts_pred_probs[:, concept_idx],
-                concepts_true[:, concept_idx].float(),
-                reduction=self.reduction,
-            )
-            concepts_loss += c_loss
-        concepts_loss = self.alpha * concepts_loss
+        concepts_loss = self.compute_concept_loss(concepts_true, concepts_pred_probs)
 
         if self.num_classes == 2:
             # Logits to probs
@@ -110,6 +99,19 @@ class CBLoss(nn.Module):
 
         return target_loss, concepts_loss, total_loss
 
+
+    def compute_concept_loss(self, concepts_true, concepts_pred_probs):
+        concepts_true = concepts_true.float() # [B, C]    
+        concepts_loss = F.binary_cross_entropy(
+            concepts_pred_probs, concepts_true , reduction='none'
+        ).double() #  [B, C]
+    
+        if self.reduction == 'mean':
+            concepts_loss = concepts_loss.mean(dim=0).sum()
+        elif self.reduction == 'sum':
+            concepts_loss = concepts_loss.sum(dim=0).sum()
+    
+        return (self.alpha * concepts_loss)
 
 class SCBLoss(nn.Module):
     """

--- a/models/losses.py
+++ b/models/losses.py
@@ -104,7 +104,7 @@ class CBLoss(nn.Module):
         concepts_true = concepts_true.float() # [B, C]    
         concepts_loss = F.binary_cross_entropy(
             concepts_pred_probs, concepts_true , reduction='none'
-        ).double() #  [B, C]
+        ) #  [B, C]
     
         if self.reduction == 'mean':
             concepts_loss = concepts_loss.mean(dim=0).sum()


### PR DESCRIPTION
This change replaces the concept loss logic computation from the CBM with a vectorized implementation. It is a no diff in terms of metrics as you can see below. But it does make this loss computation significantly faster

I wrote some profiling code in another file I won't contribute:

Using the same numbers as CBM, batch_size=64, num_concepts=112

compute_concept_loss_og time over 1000 runs: 5.444659s
compute_concept_loss_vectorized time over 1000 runs: 0.057705s

So it is a lot faster

Even on the end to end 300 epochs of training it is several minutes (>4) of savings on my machine



```
---------------- vectorized 300 no double

TRAINING FINISHED

EVALUATION ON THE TEST SET:

Epoch 300: 100%|████████████████████████████████████████████████████████████████████████| 91/91 [00:23<00:00,  3.92it/s]
Test: target_loss: 1.567 prec_loss: 0.000 concepts_loss: 16.392 total_loss: 17.959 y_accuracy: 0.699 c_accuracy: 0.951 complete_c_accuracy: 0.449 target_jaccard: 0.537 concept_jaccard: 0.776 y_AUROC: 0.986 y_AUPR: 0.748 y_Brier: 0.438 y_ECE: 0.123 y_TL-ECE: 0.138 c_AUROC: 0.977 c_AUPR: 0.921 c_Brier: 0.038 c_ECE: 0.024 c_TL-ECE: 0.042


real    82m29.957s

---------------- original 300
TRAINING FINISHED

EVALUATION ON THE TEST SET:

Epoch 300: 100%|████████████████████████████████████████████████████████████████████████| 91/91 [00:35<00:00,  2.53it/s]
Test: target_loss: 1.567 prec_loss: 0.000 concepts_loss: 16.392 total_loss: 17.959 y_accuracy: 0.699 c_accuracy: 0.951 complete_c_accuracy: 0.449 target_jaccard: 0.537 concept_jaccard: 0.776 y_AUROC: 0.986 y_AUPR: 0.748 y_Brier: 0.438 y_ECE: 0.123 y_TL-ECE: 0.138 c_AUROC: 0.977 c_AUPR: 0.921 c_Brier: 0.038 c_ECE: 0.024 c_TL-ECE: 0.042


real    86m47.389s
```