### PR TITLE
Setting persistent workers to True for both train and val. 

### DIFF
--- a/utils/data.py
+++ b/utils/data.py
@@ -87,6 +87,7 @@ def get_data(config_base, config, gen):
         pin_memory=True,
         generator=gen,
         drop_last=True,
+        persistent_workers=True,
     )
     val_loader = DataLoader(
         validset,
@@ -95,6 +96,7 @@ def get_data(config_base, config, gen):
         num_workers=config.workers,
         pin_memory=True,
         generator=gen,
+        persistent_workers=True,
     )
     test_loader = DataLoader(
         testset,


### PR DESCRIPTION
This has some affect on the sequence of random numbers,  but saves us the overhead of creating and destroying our worker processes every time we exhaust our dataset. More interestingly it unblocks the next optimization which will follow in the next pull request  "caching".

I.e. the  epoch 0 pre training, epoch 1 numbers are identical, but epoch 2 onwards slightly diverges as the example order is different

The final metrics are very close though


`persistent_workers=False`
```
Epoch 0: 100%|██████████████████████████████████████████████████████████████████████████| 19/19 [00:03<00:00,  5.71it/s]
Epoch 0, Validation: target_loss: 5.362 prec_loss: 0.000 concepts_loss: 83.879 total_loss: 89.241 y_accuracy: 0.008 c_accuracy: 0.502 complete_c_accuracy: 0.000 target_jaccard: 0.004 concept_jaccard: 0.157 y_AUROC: 0.517 y_AUPR: 0.014 y_Brier: 0.996 y_ECE: 0.005 y_TL-ECE: 0.005 c_AUROC: 0.510 c_AUPR: 0.224 c_Brier: 0.274 c_ECE: 0.327 c_TL-ECE: 0.341

Epoch 1: 100%|██████████████████████████████████████████████████████████████████████████| 74/74 [00:16<00:00,  4.51it/s]
Epoch 1, Train     : target_loss: 5.439 prec_loss: 0.000 concepts_loss: 50.986 total_loss: 56.425 y_accuracy: 0.008 c_accuracy: 0.796 complete_c_accuracy: 0.000 target_jaccard: 0.004 concept_jaccard: 0.288
Epoch 2: 100%|██████████████████████████████████████████████████████████████████████████| 74/74 [00:16<00:00,  4.53it/s]
Epoch 2, Train     : target_loss: 5.266 prec_loss: 0.000 concepts_loss: 36.448 total_loss: 41.713 y_accuracy: 0.017 c_accuracy: 0.866 complete_c_accuracy: 0.002 target_jaccard: 0.009 concept_jaccard: 0.419
Epoch 3: 100%|██████████████████████████████████████████████████████████████████████████| 74/74 [00:16<00:00,  4.50it/s]
Epoch 3, Train     : target_loss: 4.962 prec_loss: 0.000 concepts_loss: 33.430 total_loss: 38.392 y_accuracy: 0.033 c_accuracy: 0.874 complete_c_accuracy: 0.003 target_jaccard: 0.017 concept_jaccard: 0.458
Epoch 4: 100%|██████████████████████████████████████████████████████████████████████████| 74/74 [00:16<00:00,  4.56it/s]
Epoch 4, Train     : target_loss: 4.689 prec_loss: 0.000 concepts_loss: 31.472 total_loss: 36.160 y_accuracy: 0.053 c_accuracy: 0.881 complete_c_accuracy: 0.002 target_jaccard: 0.027 concept_jaccard: 0.487
Epoch 5: 100%|██████████████████████████████████████████████████████████████████████████| 74/74 [00:16<00:00,  4.40it/s]
Epoch 5, Train     : target_loss: 4.420 prec_loss: 0.000 concepts_loss: 29.718 total_loss: 34.138 y_accuracy: 0.075 c_accuracy: 0.888 complete_c_accuracy: 0.006 target_jaccard: 0.039 concept_jaccard: 0.517

Epoch 300: 100%|████████████████████████████████████████████████████████████████████████| 74/74 [00:15<00:00,  4.64it/s]
Epoch 300, Train     : target_loss: 0.238 prec_loss: 0.000 concepts_loss: 2.878 total_loss: 3.117 y_accuracy: 0.950 c_accuracy: 0.990 complete_c_accuracy: 0.879 target_jaccard: 0.904 concept_jaccard: 0.953

TRAINING FINISHED

EVALUATION ON THE TEST SET:

Epoch 300: 100%|████████████████████████████████████████████████████████████████████████| 91/91 [00:13<00:00,  6.62it/s]
Test: target_loss: 1.567 prec_loss: 0.000 concepts_loss: 16.392 total_loss: 17.959 y_accuracy: 0.699 c_accuracy: 0.951 complete_c_accuracy: 0.449 target_jaccard: 0.537 concept_jaccard: 0.776 y_AUROC: 0.986 y_AUPR: 0.748 y_Brier: 0.438 y_ECE: 0.123 y_TL-ECE: 0.138 c_AUROC: 0.977 c_AUPR: 0.921 c_Brier: 0.038 c_ECE: 0.024 c_TL-ECE: 0.042


real    81m41.152s
```





`persistent_workers=True`
```
EVALUATION ON THE VALIDATION SET:

Epoch 0: 100%|██████████████████████████████████████████████████████████████████████████| 19/19 [00:03<00:00,  5.97it/s]
Epoch 0, Validation: target_loss: 5.362 prec_loss: 0.000 concepts_loss: 83.879 total_loss: 89.241 y_accuracy: 0.008 c_accuracy: 0.502 complete_c_accuracy: 0.000 target_jaccard: 0.004 concept_jaccard: 0.157 y_AUROC: 0.517 y_AUPR: 0.014 y_Brier: 0.996 y_ECE: 0.005 y_TL-ECE: 0.005 c_AUROC: 0.510 c_AUPR: 0.224 c_Brier: 0.274 c_ECE: 0.327 c_TL-ECE: 0.341

Epoch 1: 100%|██████████████████████████████████████████████████████████████████████████| 74/74 [00:16<00:00,  4.50it/s]
Epoch 1, Train     : target_loss: 5.439 prec_loss: 0.000 concepts_loss: 50.986 total_loss: 56.425 y_accuracy: 0.008 c_accuracy: 0.796 complete_c_accuracy: 0.000 target_jaccard: 0.004 concept_jaccard: 0.288
Epoch 2: 100%|██████████████████████████████████████████████████████████████████████████| 74/74 [00:16<00:00,  4.42it/s]
Epoch 2, Train     : target_loss: 5.267 prec_loss: 0.000 concepts_loss: 36.235 total_loss: 41.501 y_accuracy: 0.017 c_accuracy: 0.866 complete_c_accuracy: 0.001 target_jaccard: 0.009 concept_jaccard: 0.421
Epoch 3: 100%|██████████████████████████████████████████████████████████████████████████| 74/74 [00:16<00:00,  4.50it/s]
Epoch 3, Train     : target_loss: 4.959 prec_loss: 0.000 concepts_loss: 33.484 total_loss: 38.443 y_accuracy: 0.031 c_accuracy: 0.874 complete_c_accuracy: 0.002 target_jaccard: 0.016 concept_jaccard: 0.457
Epoch 4: 100%|██████████████████████████████████████████████████████████████████████████| 74/74 [00:16<00:00,  4.55it/s]
Epoch 4, Train     : target_loss: 4.692 prec_loss: 0.000 concepts_loss: 31.523 total_loss: 36.215 y_accuracy: 0.044 c_accuracy: 0.881 complete_c_accuracy: 0.003 target_jaccard: 0.023 concept_jaccard: 0.486
Epoch 5: 100%|██████████████████████████████████████████████████████████████████████████| 74/74 [00:16<00:00,  4.48it/s]
Epoch 5, Train     : target_loss: 4.424 prec_loss: 0.000 concepts_loss: 29.738 total_loss: 34.162 y_accuracy: 0.068 c_accuracy: 0.888 complete_c_accuracy: 0.003 target_jaccard: 0.035 concept_jaccard: 0.516


Epoch 300: 100%|████████████████████████████████████████████████████████████████████████| 74/74 [00:15<00:00,  4.64it/s]
Epoch 300, Train     : target_loss: 0.234 prec_loss: 0.000 concepts_loss: 2.814 total_loss: 3.048 y_accuracy: 0.950 c_accuracy: 0.990 complete_c_accuracy: 0.878 target_jaccard: 0.905 concept_jaccard: 0.954

TRAINING FINISHED

EVALUATION ON THE TEST SET:

Epoch 300: 100%|████████████████████████████████████████████████████████████████████████| 91/91 [00:13<00:00,  6.63it/s]
Test: target_loss: 1.683 prec_loss: 0.000 concepts_loss: 17.032 total_loss: 18.715 y_accuracy: 0.691 c_accuracy: 0.949 complete_c_accuracy: 0.451 target_jaccard: 0.528 concept_jaccard: 0.770 y_AUROC: 0.984 y_AUPR: 0.733 y_Brier: 0.454 y_ECE: 0.125 y_TL-ECE: 0.138 c_AUROC: 0.975 c_AUPR: 0.916 c_Brier: 0.040 c_ECE: 0.025 c_TL-ECE: 0.043


real    81m0.630s
```

Not sure how robust that 40 second saving is, but there should be some small saving