### PR TITLE
Add multiprocessing shared system memory caching to CUB dataset.

### DIFF
--- a/datasets/CUB_dataset.py
+++ b/datasets/CUB_dataset.py
@@ -25,50 +25,212 @@ Functions:
     get_CIFAR100_CBM_dataloader: Returns DataLoaders for training, validation, and testing splits.
 """
 
-
+import ctypes
 import os
 import pickle
 from PIL import Image
 import numpy as np
+import multiprocessing as mp
+
+import torch
 from torch.utils.data import Dataset
 import torchvision.transforms as transforms
 
 
-class CUB_DatasetGenerator(Dataset):
-    """CUB Dataset object"""
+class CUB_DatasetGenerator(Dataset): 
+    """CUB Dataset object with caching"""
+ 
+    def __init__(self, data_pkl, transform=None, cache=False): 
+        """ 
+        Arguments: 
+        data_pkl: list of data dictionaries containing img_path, class_label, attribute_label
+        transform: whether to apply any special transformation. Default = None, i.e. use standard ImageNet preprocessing 
+        cache: Whether to cache the dataset in shared system RAM.
+        """ 
+        self.data = data_pkl 
+        self.transform = transform 
+        self.cache = cache
 
-    def __init__(self, data_pkl, transform=None):
+        num_samples = len(data_pkl) 
+        
+        # Maximum possible dimensions from CUB 
+        max_height = 500 
+        max_width = 500 
+        data_dims = (3, max_height, max_width) 
+        dimension = int(np.prod(data_dims)) 
+        
+        if self.cache:
+            # Create shared array for image data (padded to max size)
+            shared_array_base = mp.Array(
+                ctypes.c_uint8, num_samples * dimension 
+            ) 
+            shared_array = np.ctypeslib.as_array(shared_array_base.get_obj()) 
+            shared_array = shared_array.reshape(num_samples, *data_dims) 
+            self.image_cache = torch.from_numpy(shared_array)
+            
+            # Create shared array for image dimensions and validity
+            # Format: [height, width] per image, initialized to [-1, -1] (invalid)
+            dims_array_base = mp.Array(
+                ctypes.c_int, num_samples * 2  # 2 values per image: height, width
+            )
+            dims_array = np.ctypeslib.as_array(dims_array_base.get_obj())
+            dims_array = dims_array.reshape(num_samples, 2)
+            self.dims_cache = torch.from_numpy(dims_array)
+            self.dims_cache.fill_(-1)  # Initialize to -1 to indicate not cached
+            
+            # CUB has 112 binary attributes - we need 112 bits = 14 bytes per sample
+            # We'll use 15 bytes (120 bits) for easier alignment and future expansion
+            attr_size = len(data_pkl[0]["attribute_label"])
+            self.num_attributes = attr_size
+            bytes_per_sample = (attr_size + 7) // 8  # Round up to nearest byte
+
+            attr_array_base = mp.Array(
+                ctypes.c_uint8, num_samples * bytes_per_sample
+            )
+            attr_array = np.ctypeslib.as_array(attr_array_base.get_obj())
+            attr_array = attr_array.reshape(num_samples, bytes_per_sample)
+            self.attr_cache = torch.from_numpy(attr_array)
+            self.attr_cache.fill_(0)  # Initialize to 0
+            
+            # Create shared array for class labels
+            label_array_base = mp.Array(
+                ctypes.c_int, num_samples
+            )
+            label_array = np.ctypeslib.as_array(label_array_base.get_obj())
+            self.label_cache = torch.from_numpy(label_array)
+            self.label_cache.fill_(-1)  # Initialize to -1 to indicate not cached
+
+    def _pack_attributes(self, attributes):
         """
-        Arguments:
-        pkl_file_paths: list of full path to all the pkl data
-        transform: whether to apply any special transformation. Default = None, i.e. use standard ImageNet preprocessing
+        Pack binary attributes into bytes.
+        
+        Args:
+            attributes: numpy array of binary values (0 or 1)
+        
+        Returns:
+            Packed byte array
         """
-        self.data = data_pkl
-        self.transform = transform
-        self.img_index = [0, 1, 2, 3]  # Placeholder
+        # Ensure attributes are binary
+        attributes = np.array(attributes, dtype=np.uint8)
+        attributes = np.clip(attributes, 0, 1)  # Ensure binary
+        
+        # Calculate number of bytes needed
+        n_bytes = (len(attributes) + 7) // 8
+        packed = np.zeros(n_bytes, dtype=np.uint8)
+        
+        # Pack bits into bytes
+        for i, attr in enumerate(attributes):
+            if attr:
+                byte_idx = i // 8
+                bit_idx = i % 8
+                packed[byte_idx] |= (1 << bit_idx)
+        
+        return packed
+    
+    def _unpack_attributes(self, packed_bytes):
+        """
+        Unpack bytes into binary attributes.
+        
+        Args:
+            packed_bytes: byte array
+        
+        Returns:
+            numpy array of binary values (0 or 1)
+        """
+        attributes = np.zeros(self.num_attributes, dtype=np.float64)
+        
+        for i in range(self.num_attributes):
+            byte_idx = i // 8
+            bit_idx = i % 8
+            if byte_idx < len(packed_bytes):
+                bit_value = (packed_bytes[byte_idx] >> bit_idx) & 1
+                # Store as float64 to match original
+                attributes[i] = float(bit_value)
+        
+        # Return as float32 for consistency with model expectations
+        return attributes.astype(np.float32)
 
-    def __getitem__(self, index):
-        # Gets an element of the dataset
-        img_data = self.data[index]
-        img_path = img_data["img_path"]
-        imageData = Image.open(img_path).convert("RGB")
-        # imageData = imageData.resize((224, 224))
-        image_label = img_data["class_label"]
+    def _is_cached(self, index):
+        """Check if an image is already cached by looking at dimensions"""
+        if self.cache:
+            return self.dims_cache[index][0] != -1 and self.dims_cache[index][1] != -1
+        return False
 
-        image_attr = np.array(img_data["attribute_label"])
+    def _cache_image(self, index, image_pil, image_attr, image_label):
+        """Cache an image and its metadata in the shared arrays"""
+        # Convert PIL image to numpy array
+        img_array = np.array(image_pil)
+        h, w = img_array.shape[:2]
+        
+        # Store dimensions
+        self.dims_cache[index] = torch.tensor([h, w])
+        
+        # Pad image to maximum size if necessary
+        if len(img_array.shape) == 2:  # Grayscale
+            img_array = np.stack([img_array] * 3, axis=-1)  # Convert to RGB
+        
+        # Convert to CHW format and pad
+        img_tensor = torch.from_numpy(img_array).permute(2, 0, 1)  # HWC -> CHW
+        
+        # Pad to maximum size
+        padded_img = torch.zeros((3, 500, 500), dtype=torch.uint8)
+        padded_img[:, :h, :w] = img_tensor
+        
+        # Store in cache
+        self.image_cache[index] = padded_img
+        
+        # Pack and store attributes
+        packed_attrs = self._pack_attributes(image_attr)
+        self.attr_cache[index] = torch.from_numpy(packed_attrs)
+        
+        self.label_cache[index] = image_label
 
-        if self.transform != None:
-            imageData = self.transform(imageData)
+    def _get_cached_image(self, index):
+        """Retrieve a cached image with its original dimensions"""
+        h, w = self.dims_cache[index]
+        h, w = int(h), int(w)
+        
+        # Extract the image without padding
+        img_tensor = self.image_cache[index][:, :h, :w]  # CHW format
+        
+        # Convert back to PIL Image (HWC format)
+        img_array = img_tensor.permute(1, 2, 0).numpy()  # CHW -> HWC
+        image_pil = Image.fromarray(img_array)
+        
+        # Unpack attributes
+        packed_attrs = self.attr_cache[index].numpy()
+        image_attr = self._unpack_attributes(packed_attrs)
+        
+        image_label = int(self.label_cache[index])
+        
+        return image_pil, image_attr, image_label
 
-        # Return a tuple of images, labels, and protected attributes
-        return {
-            "img_code": index,
-            "labels": image_label,
-            "features": imageData,
-            "concepts": image_attr,
+    def __getitem__(self, index): 
+        # Check if already cached
+        if self._is_cached(index):
+            image_data, image_attr, image_label = self._get_cached_image(index)
+        else: 
+            img_data = self.data[index] 
+            img_path = img_data["img_path"] 
+            image_data = Image.open(img_path).convert("RGB") 
+            image_label = img_data["class_label"] 
+            image_attr = np.array(img_data["attribute_label"])
+            
+            if self.cache:
+                self._cache_image(index, image_data, image_attr, image_label)
+        
+        if self.transform is not None: 
+            image_data = self.transform(image_data) 
+ 
+        # Return a tuple of images, labels, and protected attributes 
+        return { 
+            "img_code": index, 
+            "labels": image_label, 
+            "features": image_data, 
+            "concepts": image_attr,  # This is now float32 array as expected
         }
-
-    def __len__(self):
+ 
+    def __len__(self): 
         return len(self.data)
 
 
@@ -127,7 +289,6 @@ def get_CUB_dataloaders(config):
 
     # Following the transformations from CBM paper
     resol = 299
-    # resized_resol = int(resol * 256 / 224)
     train_transform = transforms.Compose(
         [
             transforms.ColorJitter(brightness=32 / 255, saturation=(0.5, 1.5)),
@@ -150,9 +311,9 @@ def get_CUB_dataloaders(config):
 
     # Datasets
     image_datasets = {
-        "train": CUB_DatasetGenerator(train_imgs, transform=train_transform),
-        "val": CUB_DatasetGenerator(val_imgs, transform=test_transform),
-        "test": CUB_DatasetGenerator(test_imgs, transform=test_transform),
+        "train": CUB_DatasetGenerator(train_imgs, transform=train_transform, cache=True),
+        "val": CUB_DatasetGenerator(val_imgs, transform=test_transform, cache=True),
+        "test": CUB_DatasetGenerator(test_imgs, transform=test_transform, cache=False),
     }
 
     return (


### PR DESCRIPTION
This pull request uses the Python multiprocessing library to define a multiprocessing (https://docs.python.org/3/library/multiprocessing.html) shared memory array of size num_samples * 3 * 500 * 500 for train and val and then stores the images there on first load. There is an auxiliary array that stores the height and width of the original images. You see now that the first epoch for train and val are slower as they fill the cache, but the subsequent iterations are much faster.

The numbers are identical to the previous pull request https://github.com/mvandenhi/SCBM/pull/6 but there is a 30 min time saving (~40%), cutting from 81m0.630s to 50m3.617s. Very nice!

Even nicer, if you set the num_workers to 12 on my machine it changes the numbers slightly as it shuffles the example orders (see below), but reduces the runtime way, way more bringing it down by another 75% to under 12:30



````
EVALUATION ON THE VALIDATION SET:

Epoch 0: 100%|██████████████████████████████████████████████████████████████████████████| 19/19 [00:03<00:00,  5.45it/s]
Epoch 0, Validation: target_loss: 5.362 prec_loss: 0.000 concepts_loss: 83.879 total_loss: 89.241 y_accuracy: 0.008 c_accuracy: 0.502 complete_c_accuracy: 0.000 target_jaccard: 0.004 concept_jaccard: 0.157 y_AUROC: 0.517 y_AUPR: 0.014 y_Brier: 0.996 y_ECE: 0.005 y_TL-ECE: 0.005 c_AUROC: 0.510 c_AUPR: 0.224 c_Brier: 0.274 c_ECE: 0.327 c_TL-ECE: 0.341

Epoch 1: 100%|██████████████████████████████████████████████████████████████████████████| 74/74 [00:17<00:00,  4.24it/s]
Epoch 1, Train     : target_loss: 5.439 prec_loss: 0.000 concepts_loss: 50.986 total_loss: 56.425 y_accuracy: 0.008 c_accuracy: 0.796 complete_c_accuracy: 0.000 target_jaccard: 0.004 concept_jaccard: 0.288
Epoch 2: 100%|██████████████████████████████████████████████████████████████████████████| 74/74 [00:09<00:00,  7.58it/s]
Epoch 2, Train     : target_loss: 5.267 prec_loss: 0.000 concepts_loss: 36.235 total_loss: 41.501 y_accuracy: 0.017 c_accuracy: 0.866 complete_c_accuracy: 0.001 target_jaccard: 0.009 concept_jaccard: 0.421
Epoch 3: 100%|██████████████████████████████████████████████████████████████████████████| 74/74 [00:09<00:00,  7.71it/s]
Epoch 3, Train     : target_loss: 4.959 prec_loss: 0.000 concepts_loss: 33.484 total_loss: 38.443 y_accuracy: 0.031 c_accuracy: 0.874 complete_c_accuracy: 0.002 target_jaccard: 0.016 concept_jaccard: 0.457
Epoch 4: 100%|██████████████████████████████████████████████████████████████████████████| 74/74 [00:09<00:00,  7.80it/s]
Epoch 4, Train     : target_loss: 4.692 prec_loss: 0.000 concepts_loss: 31.523 total_loss: 36.215 y_accuracy: 0.044 c_accuracy: 0.881 complete_c_accuracy: 0.003 target_jaccard: 0.023 concept_jaccard: 0.486
Epoch 5: 100%|██████████████████████████████████████████████████████████████████████████| 74/74 [00:09<00:00,  7.76it/s]
Epoch 5, Train     : target_loss: 4.424 prec_loss: 0.000 concepts_loss: 29.738 total_loss: 34.162 y_accuracy: 0.068 c_accuracy: 0.888 complete_c_accuracy: 0.003 target_jaccard: 0.035 concept_jaccard: 0.516


Epoch 300: 100%|████████████████████████████████████████████████████████████████████████| 74/74 [00:09<00:00,  7.71it/s]
Epoch 300, Train     : target_loss: 0.234 prec_loss: 0.000 concepts_loss: 2.814 total_loss: 3.048 y_accuracy: 0.950 c_accuracy: 0.990 complete_c_accuracy: 0.878 target_jaccard: 0.905 concept_jaccard: 0.954

TRAINING FINISHED

EVALUATION ON THE TEST SET:

Epoch 300: 100%|████████████████████████████████████████████████████████████████████████| 91/91 [00:18<00:00,  4.92it/s]
Test: target_loss: 1.683 prec_loss: 0.000 concepts_loss: 17.032 total_loss: 18.715 y_accuracy: 0.691 c_accuracy: 0.949 complete_c_accuracy: 0.451 target_jaccard: 0.528 concept_jaccard: 0.770 y_AUROC: 0.984 y_AUPR: 0.733 y_Brier: 0.454 y_ECE: 0.125 y_TL-ECE: 0.138 c_AUROC: 0.975 c_AUPR: 0.916 c_Brier: 0.040 c_ECE: 0.025 c_TL-ECE: 0.043


real    50m3.617s
```

This is a 30 min saving, cutting from 81m0.630s to 50m3.617s

Nice!

Even nicer, if you set the num_workers to 12 on my machine it changes the numbers slightly as it shuffles the example orders, but reduces the runtime way, way more bringing it down by another 75% to under 12:30

```
EVALUATION ON THE VALIDATION SET:

Epoch 0: 100%|██████████████████████████████████████████████████████████████████████████| 19/19 [00:01<00:00, 11.39it/s]
Epoch 0, Validation: target_loss: 5.362 prec_loss: 0.000 concepts_loss: 83.879 total_loss: 89.241 y_accuracy: 0.008 c_accuracy: 0.502 complete_c_accuracy: 0.000 target_jaccard: 0.004 concept_jaccard: 0.157 y_AUROC: 0.517 y_AUPR: 0.014 y_Brier: 0.996 y_ECE: 0.005 y_TL-ECE: 0.005 c_AUROC: 0.510 c_AUPR: 0.224 c_Brier: 0.274 c_ECE: 0.327 c_TL-ECE: 0.341

Epoch 1: 100%|██████████████████████████████████████████████████████████████████████████| 74/74 [00:04<00:00, 17.08it/s]
Epoch 1, Train     : target_loss: 5.433 prec_loss: 0.000 concepts_loss: 50.987 total_loss: 56.420 y_accuracy: 0.007 c_accuracy: 0.797 complete_c_accuracy: 0.000 target_jaccard: 0.004 concept_jaccard: 0.288
Epoch 2: 100%|██████████████████████████████████████████████████████████████████████████| 74/74 [00:02<00:00, 31.41it/s]
Epoch 2, Train     : target_loss: 5.267 prec_loss: 0.000 concepts_loss: 36.444 total_loss: 41.711 y_accuracy: 0.018 c_accuracy: 0.865 complete_c_accuracy: 0.002 target_jaccard: 0.009 concept_jaccard: 0.416
Epoch 3: 100%|██████████████████████████████████████████████████████████████████████████| 74/74 [00:02<00:00, 32.73it/s]
Epoch 3, Train     : target_loss: 4.956 prec_loss: 0.000 concepts_loss: 33.471 total_loss: 38.427 y_accuracy: 0.031 c_accuracy: 0.874 complete_c_accuracy: 0.002 target_jaccard: 0.016 concept_jaccard: 0.457
Epoch 4: 100%|██████████████████████████████████████████████████████████████████████████| 74/74 [00:02<00:00, 32.54it/s]
Epoch 4, Train     : target_loss: 4.695 prec_loss: 0.000 concepts_loss: 31.403 total_loss: 36.098 y_accuracy: 0.049 c_accuracy: 0.881 complete_c_accuracy: 0.004 target_jaccard: 0.025 concept_jaccard: 0.488
Epoch 5: 100%|██████████████████████████████████████████████████████████████████████████| 74/74 [00:02<00:00, 32.89it/s]
Epoch 5, Train     : target_loss: 4.429 prec_loss: 0.000 concepts_loss: 29.595 total_loss: 34.024 y_accuracy: 0.065 c_accuracy: 0.889 complete_c_accuracy: 0.006 target_jaccard: 0.034 concept_jaccard: 0.520

Epoch 300: 100%|████████████████████████████████████████████████████████████████████████| 74/74 [00:02<00:00, 31.76it/s]
Epoch 300, Train     : target_loss: 0.217 prec_loss: 0.000 concepts_loss: 2.726 total_loss: 2.943 y_accuracy: 0.954 c_accuracy: 0.991 complete_c_accuracy: 0.883 target_jaccard: 0.911 concept_jaccard: 0.955

TRAINING FINISHED

EVALUATION ON THE TEST SET:

Epoch 300: 100%|████████████████████████████████████████████████████████████████████████| 91/91 [00:03<00:00, 22.84it/s]
Test: target_loss: 1.657 prec_loss: 0.000 concepts_loss: 17.645 total_loss: 19.302 y_accuracy: 0.689 c_accuracy: 0.948 complete_c_accuracy: 0.444 target_jaccard: 0.526 concept_jaccard: 0.766 y_AUROC: 0.986 y_AUPR: 0.740 y_Brier: 0.455 y_ECE: 0.135 y_TL-ECE: 0.150 c_AUROC: 0.975 c_AUPR: 0.917 c_Brier: 0.040 c_ECE: 0.027 c_TL-ECE: 0.047


real    12m26.667s
```