### PR TITLE
Add the option to use torch.compile

### DIFF
--- a/configs/model/model_defaults.yaml
+++ b/configs/model/model_defaults.yaml
@@ -15,6 +15,8 @@ weight_decay: 0 # Weight decay
 train_batch_size: 64 # Batch size for the training set
 val_batch_size: 64 # Batch size for the validation and test sets
 
+compile: False # Whether to use Torch.compile to optimize the model. Requires Triton
+
 j_epochs: 300 # Number of epochs for joint training
 c_epochs: 200 # Number of epochs for first stage training in sequential & independent training
 t_epochs: 100 # Number of epochs for second stage training in sequential & independent training

--- a/models/models.py
+++ b/models/models.py
@@ -18,13 +18,19 @@ def create_model(config):
     """
     Parse the configuration file and return a relevant model
     """
-    if config.model.model == "cbm":
-        return CBM(config)
-    elif config.model.model == "scbm":
-        return SCBM(config)
-    else:
+    model = None
+    if config.model.model not in ["cbm", "scbm"]:
         print("Could not create model with name ", config.model, "!")
         quit()
+    if config.model.model == "cbm":
+        model = CBM(config)
+    elif config.model.model == "scbm":
+        model = SCBM(config)
+    if config.model.compile:
+        model = torch.compile(model)
+    return model
+        
+
 
 
 class SCBM(nn.Module):


### PR DESCRIPTION
This adds the ability to use torch.compile, with it off by default as it requires Triton and hence Linux

Using it makes the first epoch slower while it compiles and all subsequent iterations a little faster

Using 12 workers 

I get ~5% speedup on the subsequent train iterations

The full 300 epochs of 12m26.667s previous goes to 11m41.538s with compile set to true, but again perturbs the RNG so enabling it gives slightly different number sequences


Epoch 300: 100%|████████████████████████████████████████████████████████████████████████| 74/74 [00:02<00:00, 32.40it/s]
Epoch 300, Train     : target_loss: 0.227 prec_loss: 0.000 concepts_loss: 2.822 total_loss: 3.049 y_accuracy: 0.954 c_accuracy: 0.990 complete_c_accuracy: 0.886 target_jaccard: 0.912 concept_jaccard: 0.954

TRAINING FINISHED

EVALUATION ON THE TEST SET:

Epoch 300: 100%|████████████████████████████████████████████████████████████████████████| 91/91 [00:03<00:00, 24.61it/s]
Test: target_loss: 1.599 prec_loss: 0.000 concepts_loss: 17.135 total_loss: 18.734 y_accuracy: 0.701 c_accuracy: 0.949 complete_c_accuracy: 0.444 target_jaccard: 0.539 concept_jaccard: 0.769 y_AUROC: 0.986 y_AUPR: 0.746 y_Brier: 0.443 y_ECE: 0.125 y_TL-ECE: 0.137 c_AUROC: 0.976 c_AUPR: 0.919 c_Brier: 0.040 c_ECE: 0.025 c_TL-ECE: 0.045



https://docs.pytorch.org/tutorials/intermediate/torch_compile_tutorial.html

https://docs.pytorch.org/assets/pytorch2-2.pdf