### PR TITLE
Prevent negative losses in SCBM model.

### DIFF
--- a/models/losses.py
+++ b/models/losses.py
@@ -136,12 +136,8 @@ class SCBLoss(nn.Module):
         self.reg_precision = config.reg_precision
         self.reg_weight = config.reg_weight
 
-        alpha = alpha if config.training_mode == "joint" else 1.0
-
-        # Register these as buffer so they move with .to(device) calls
-        self.register_buffer('log_num_mc', 
-                           torch.tensor(math.log(config.num_monte_carlo)))
-        self.register_buffer('alpha_tensor', torch.tensor(alpha))
+        self.log_num_mc = math.log(config.num_monte_carlo)
+        self.alpha = alpha if config.training_mode == "joint" else 1.0
 
     def forward(
         self,
@@ -220,4 +216,4 @@ class SCBLoss(nn.Module):
         )  # [B], logsumexp for numerical stability due to shift invariance
         # The concept loss computation is bounded by - log_num_mc adding log_num_mc moves
         # bound to 0. Preventing negative losses.
-        return self.alpha_tensor * (torch.mean(mcmc_loss) + self.log_num_mc)
+        return self.alpha * (torch.mean(mcmc_loss) + self.log_num_mc)

--- a/models/losses.py
+++ b/models/losses.py
@@ -218,5 +218,6 @@ class SCBLoss(nn.Module):
         mcmc_loss = -torch.logsumexp(
             intermediate_concepts_loss, dim=1
         )  # [B], logsumexp for numerical stability due to shift invariance
-        # This is bounded by - log_num_mc adding log_num_mc moves to bound to 0.
+        # The concept loss computation is bounded by - log_num_mc adding log_num_mc moves
+        #         # bound to 0. Preventing negative losses.
         return self.alpha_tensor * (torch.mean(mcmc_loss) + self.log_num_mc)

--- a/models/losses.py
+++ b/models/losses.py
@@ -219,5 +219,5 @@ class SCBLoss(nn.Module):
             intermediate_concepts_loss, dim=1
         )  # [B], logsumexp for numerical stability due to shift invariance
         # The concept loss computation is bounded by - log_num_mc adding log_num_mc moves
-        #         # bound to 0. Preventing negative losses.
+        # bound to 0. Preventing negative losses.
         return self.alpha_tensor * (torch.mean(mcmc_loss) + self.log_num_mc)

--- a/models/losses.py
+++ b/models/losses.py
@@ -2,6 +2,8 @@
 Utility methods for constructing loss functions
 """
 
+import math
+
 import torch
 import torch.nn as nn
 import torch.nn.functional as F
@@ -131,9 +133,15 @@ class SCBLoss(nn.Module):
         """
         super(SCBLoss, self).__init__()
         self.num_classes = num_classes
-        self.alpha = alpha if config.training_mode == "joint" else 1.0
         self.reg_precision = config.reg_precision
         self.reg_weight = config.reg_weight
+
+        alpha = alpha if config.training_mode == "joint" else 1.0
+
+        # Register these as buffer so they move with .to(device) calls
+        self.register_buffer('log_num_mc', 
+                           torch.tensor(math.log(config.num_monte_carlo)))
+        self.register_buffer('alpha_tensor', torch.tensor(alpha))
 
     def forward(
         self,
@@ -210,4 +218,5 @@ class SCBLoss(nn.Module):
         mcmc_loss = -torch.logsumexp(
             intermediate_concepts_loss, dim=1
         )  # [B], logsumexp for numerical stability due to shift invariance
-        return self.alpha * torch.mean(mcmc_loss)
+        # This is bounded by - log_num_mc adding log_num_mc moves to bound to 0.
+        return self.alpha_tensor * (torch.mean(mcmc_loss) + self.log_num_mc)

--- a/models/losses.py
+++ b/models/losses.py
@@ -158,20 +158,7 @@ class SCBLoss(nn.Module):
         Returns:
             Tensor: Target loss, concept loss, precision loss, and total loss.
         """
-
-        assert torch.all((concepts_true == 0) | (concepts_true == 1))
-        concepts_true_expanded = concepts_true.unsqueeze(-1).expand_as(
-            concepts_mcmc_probs
-        )
-
-        bce_loss = F.binary_cross_entropy(
-            concepts_mcmc_probs, concepts_true_expanded.float(), reduction="none"
-        )  # [B,C,MCMC]
-        intermediate_concepts_loss = -torch.sum(bce_loss, dim=1)  # [B,MCMC]
-        mcmc_loss = -torch.logsumexp(
-            intermediate_concepts_loss, dim=1
-        )  # [B], logsumexp for numerical stability due to shift invariance
-        concepts_loss = self.alpha * torch.mean(mcmc_loss)
+        concepts_loss = self.compute_concept_loss(concepts_mcmc_probs, concepts_true)
 
         if self.num_classes == 2:
             # Logits to probs
@@ -209,3 +196,18 @@ class SCBLoss(nn.Module):
         total_loss = target_loss + concepts_loss + prec_loss
 
         return target_loss, concepts_loss, prec_loss, total_loss
+
+    def compute_concept_loss(self, concepts_mcmc_probs, concepts_true):
+        assert torch.all((concepts_true == 0) | (concepts_true == 1))
+        concepts_true_expanded = concepts_true.unsqueeze(-1).expand_as(
+            concepts_mcmc_probs
+        )
+
+        bce_loss = F.binary_cross_entropy(
+            concepts_mcmc_probs, concepts_true_expanded.float(), reduction="none"
+        )  # [B,C,MCMC]
+        intermediate_concepts_loss = -torch.sum(bce_loss, dim=1)  # [B,MCMC]
+        mcmc_loss = -torch.logsumexp(
+            intermediate_concepts_loss, dim=1
+        )  # [B], logsumexp for numerical stability due to shift invariance
+        return self.alpha * torch.mean(mcmc_loss)

--- a/models/models.py
+++ b/models/models.py
@@ -241,25 +241,8 @@ class SCBM(nn.Module):
             else:
                 c_mcmc = mcmc_relaxed
 
-        # MCMC loop for predicting label
-        y_pred_probs_i = 0
-        for i in range(self.num_monte_carlo):
-            if self.concept_learning == "hard":
-                c_i = c_mcmc[:, :, i]
-            elif self.concept_learning == "soft":
-                c_i = c_mcmc_logit[:, :, i]
-            else:
-                raise NotImplementedError
-            y_pred_logits_i = self.head(c_i)
-            if self.pred_dim == 1:
-                y_pred_probs_i += torch.sigmoid(y_pred_logits_i)
-            else:
-                y_pred_probs_i += torch.softmax(y_pred_logits_i, dim=1)
-        y_pred_probs = y_pred_probs_i / self.num_monte_carlo
-        if self.pred_dim == 1:
-            y_pred_logits = torch.logit(y_pred_probs, eps=1e-6)
-        else:
-            y_pred_logits = torch.log(y_pred_probs + 1e-6)
+        y_pred_logits = self.compute_y_pred_logits(c_mcmc, c_mcmc_logit)
+
 
         # Return concept mu for interventions
         if return_full:
@@ -309,6 +292,28 @@ class SCBM(nn.Module):
             self.sigma_concepts.apply(freeze_module)
         else:
             self.sigma_concepts.requires_grad = False
+
+    def compute_y_pred_logits(self, c_mcmc, c_mcmc_logit):
+            # MCMC loop for predicting label
+            y_pred_probs_i = 0
+            for i in range(self.num_monte_carlo):
+                if self.concept_learning == "hard":
+                    c_i = c_mcmc[:, :, i]
+                elif self.concept_learning == "soft":
+                    c_i = c_mcmc_logit[:, :, i]
+                else:
+                    raise NotImplementedError
+                y_pred_logits_i = self.head(c_i)
+                if self.pred_dim == 1:
+                    y_pred_probs_i += torch.sigmoid(y_pred_logits_i)
+                else:
+                    y_pred_probs_i += torch.softmax(y_pred_logits_i, dim=1)
+            y_pred_probs = y_pred_probs_i / self.num_monte_carlo
+            if self.pred_dim == 1:
+                y_pred_logits = torch.logit(y_pred_probs, eps=1e-6)
+            else:
+                y_pred_logits = torch.log(y_pred_probs + 1e-6)
+            return y_pred_logits
 
 
 class CBM(nn.Module):

--- a/models/models.py
+++ b/models/models.py
@@ -241,8 +241,25 @@ class SCBM(nn.Module):
             else:
                 c_mcmc = mcmc_relaxed
 
-        y_pred_logits = self.compute_y_pred_logits(c_mcmc, c_mcmc_logit)
-
+        # MCMC loop for predicting label
+        y_pred_probs_i = 0
+        for i in range(self.num_monte_carlo):
+            if self.concept_learning == "hard":
+                c_i = c_mcmc[:, :, i]
+            elif self.concept_learning == "soft":
+                c_i = c_mcmc_logit[:, :, i]
+            else:
+                raise NotImplementedError
+            y_pred_logits_i = self.head(c_i)
+            if self.pred_dim == 1:
+                y_pred_probs_i += torch.sigmoid(y_pred_logits_i)
+            else:
+                y_pred_probs_i += torch.softmax(y_pred_logits_i, dim=1)
+        y_pred_probs = y_pred_probs_i / self.num_monte_carlo
+        if self.pred_dim == 1:
+            y_pred_logits = torch.logit(y_pred_probs, eps=1e-6)
+        else:
+            y_pred_logits = torch.log(y_pred_probs + 1e-6)
 
         # Return concept mu for interventions
         if return_full:
@@ -292,28 +309,6 @@ class SCBM(nn.Module):
             self.sigma_concepts.apply(freeze_module)
         else:
             self.sigma_concepts.requires_grad = False
-
-    def compute_y_pred_logits(self, c_mcmc, c_mcmc_logit):
-            # MCMC loop for predicting label
-            y_pred_probs_i = 0
-            for i in range(self.num_monte_carlo):
-                if self.concept_learning == "hard":
-                    c_i = c_mcmc[:, :, i]
-                elif self.concept_learning == "soft":
-                    c_i = c_mcmc_logit[:, :, i]
-                else:
-                    raise NotImplementedError
-                y_pred_logits_i = self.head(c_i)
-                if self.pred_dim == 1:
-                    y_pred_probs_i += torch.sigmoid(y_pred_logits_i)
-                else:
-                    y_pred_probs_i += torch.softmax(y_pred_logits_i, dim=1)
-            y_pred_probs = y_pred_probs_i / self.num_monte_carlo
-            if self.pred_dim == 1:
-                y_pred_logits = torch.logit(y_pred_probs, eps=1e-6)
-            else:
-                y_pred_logits = torch.log(y_pred_probs + 1e-6)
-            return y_pred_logits
 
 
 class CBM(nn.Module):


### PR DESCRIPTION
Currently the SCBM concept loss has a lower bound of -log(M) and not 0 as it should, where M is the number of Monte Carlo samples. This means that as during training p(C|X) approaches 1 the concept loss turns negative as the  -log \sum_m (p(c|x)) approaches - log sum(M) and this can and does even push the total loss to become negative. This looks like a serious bug/error. However it is only being off by a constant so it is in fact not particularly important.

Fixing this issues makes it more intuitive. I thought about PyTorch's register_buffer for the variables, but did some analysis and found that passing scalars was a little bit faster
<img width="746" height="293" alt="register" src="https://github.com/user-attachments/assets/d2afd9e9-0027-46c0-bc73-3f79360fe698" />




