### PR TITLE
Vectorize the MCMC loop for predicting label in the SCBM model.

### DIFF
--- a/models/models.py
+++ b/models/models.py
@@ -82,6 +82,11 @@ class SCBM(nn.Module):
             self.num_epochs = config_model.t_epochs
         self.cov_type = config_model.cov_type
 
+        self.init_temp = 1.0
+        self.final_temp = 0.5
+        self.temp_decay_rate = (math.log(self.final_temp) - math.log(self.init_temp)) / float(self.num_epochs)
+        
+
         # Architectures
         # Encoder h(.)
         if self.encoder_arch == "FCNN":
@@ -229,7 +234,7 @@ class SCBM(nn.Module):
             c_mcmc = c_true.unsqueeze(-1).repeat(1, 1, self.num_monte_carlo).float()
         else:
             # Backpropagation necessary
-            curr_temp = self.compute_temperature(epoch, device=c_mcmc_prob.device)
+            curr_temp = self.compute_temperature(epoch)
             dist = RelaxedBernoulli(temperature=curr_temp, probs=c_mcmc_prob)
 
             # Bernoulli relaxation
@@ -293,11 +298,8 @@ class SCBM(nn.Module):
 
         return y_pred_logits
 
-    def compute_temperature(self, epoch, device):
-        final_temp = torch.tensor([0.5], device=device)
-        init_temp = torch.tensor([1.0], device=device)
-        rate = (math.log(final_temp) - math.log(init_temp)) / float(self.num_epochs)
-        curr_temp = max(init_temp * math.exp(rate * epoch), final_temp)
+    def compute_temperature(self, epoch):
+        curr_temp = max(self.init_temp * math.exp(self.temp_decay_rate * epoch), self.final_temp)
         self.curr_temp = curr_temp
         return curr_temp
 

--- a/models/models.py
+++ b/models/models.py
@@ -240,32 +240,35 @@ class SCBM(nn.Module):
                 c_mcmc = mcmc_hard - mcmc_relaxed.detach() + mcmc_relaxed
             else:
                 c_mcmc = mcmc_relaxed
-
-        # MCMC loop for predicting label
-        y_pred_probs_i = 0
-        for i in range(self.num_monte_carlo):
-            if self.concept_learning == "hard":
-                c_i = c_mcmc[:, :, i]
-            elif self.concept_learning == "soft":
-                c_i = c_mcmc_logit[:, :, i]
-            else:
-                raise NotImplementedError
-            y_pred_logits_i = self.head(c_i)
-            if self.pred_dim == 1:
-                y_pred_probs_i += torch.sigmoid(y_pred_logits_i)
-            else:
-                y_pred_probs_i += torch.softmax(y_pred_logits_i, dim=1)
-        y_pred_probs = y_pred_probs_i / self.num_monte_carlo
-        if self.pred_dim == 1:
-            y_pred_logits = torch.logit(y_pred_probs, eps=1e-6)
-        else:
-            y_pred_logits = torch.log(y_pred_probs + 1e-6)
+                
+        y_pred_logits = self.compute_y_pred_logits(c_mcmc, c_mcmc_logit)
 
         # Return concept mu for interventions
         if return_full:
             return c_mcmc_prob, c_mu, c_triang_cov, y_pred_logits
         else:
             return c_mcmc_prob, c_triang_cov, y_pred_logits
+
+    def compute_y_pred_logits(self, c_mcmc_probs, c_mcmc_logits):
+        # Pick the concept tensor: [B, C, M]
+        x = c_mcmc_probs if self.concept_learning == "hard" else c_mcmc_logits
+        B, C, M = x.shape
+
+        # Run the head over all M samples at once: reshape to [B*M, C]
+        x_flat = x.permute(0, 2, 1).reshape(B * M, C)        # [B*M, C]
+        y_logits_flat = self.head(x_flat)                     # [B*M, K] or [B*M, 1]
+
+        if self.pred_dim == 1:
+            # Binary: average Bernoulli probs then convert back to logits
+            y_probs = torch.sigmoid(y_logits_flat).view(B, M, 1).mean(dim=1)  # [B, 1]
+            y_pred_logits = torch.logit(y_probs, eps=1e-6)                    # [B, 1]
+            return y_pred_logits
+        else:
+            # Multiclass: compute log(mean softmax) in a numerically stable way:
+            # log(mean_i p_i) == logsumexp(log p_i) - log(M), where log p_i = log_softmax(logits_i)
+            y_log_probs = F.log_softmax(y_logits_flat, dim=-1).view(B, M, self.pred_dim)  # [B, M, K]
+            y_pred_log_probs = torch.logsumexp(y_log_probs, dim=1) - math.log(M)          # [B, K]
+            return y_pred_log_probs
 
     def intervene(self, c_mcmc_probs, c_mcmc_logits):
         y_pred_probs_i = 0


### PR DESCRIPTION
Currently the MCMC loop for predicting label in the SCBM model is a major bottleneck. This change vectorizes it, making the SCBM model significantly faster to train

Using 12 workers on my machine we get a reduction from ~28:30 to ~15:45. Almost half  and bringing it more into line with the CBM model which I optimized previously to ~12:30

Epoch 299: 100%|████████████████████████████████████████████████████████████████████████| 74/74 [00:06<00:00, 12.28it/s]
Epoch 299, Train     : target_loss: 0.211 prec_loss: 0.061 concepts_loss: 1.873 total_loss: 2.146 y_accuracy: 0.953 c_accuracy: 0.989 complete_c_accuracy: 0.846 target_jaccard: 0.910 concept_jaccard: 0.945
Epoch 300: 100%|████████████████████████████████████████████████████████████████████████| 74/74 [00:05<00:00, 13.22it/s]
Epoch 300, Train     : target_loss: 0.211 prec_loss: 0.060 concepts_loss: 1.866 total_loss: 2.137 y_accuracy: 0.952 c_accuracy: 0.988 complete_c_accuracy: 0.851 target_jaccard: 0.909 concept_jaccard: 0.944

TRAINING FINISHED

EVALUATION ON THE TEST SET:

Epoch 300: 100%|████████████████████████████████████████████████████████████████████████| 91/91 [00:04<00:00, 22.53it/s]
Test: target_loss: 1.319 prec_loss: 0.046 concepts_loss: 9.676 total_loss: 11.042 y_accuracy: 0.700 c_accuracy: 0.949 complete_c_accuracy: 0.450 target_jaccard: 0.538 concept_jaccard: 0.767 y_AUROC: 0.988 y_AUPR: 0.758 y_Brier: 0.425 y_ECE: 0.091 y_TL-ECE: 0.102 c_AUROC: 0.977 c_AUPR: 0.917 c_Brier: 0.039 c_ECE: 0.022 c_TL-ECE: 0.050


real    28m34.469s
user    132m34.320s
sys     15m13.396s



Epoch 300: 100%|████████████████████████████████████████████████████████████████████████| 74/74 [00:02<00:00, 25.62it/s]
Epoch 300, Train     : target_loss: 0.210 prec_loss: 0.059 concepts_loss: 1.845 total_loss: 2.115 y_accuracy: 0.950 c_accuracy: 0.989 complete_c_accuracy: 0.848 target_jaccard: 0.905 concept_jaccard: 0.945

TRAINING FINISHED

EVALUATION ON THE TEST SET:

Epoch 300: 100%|████████████████████████████████████████████████████████████████████████| 91/91 [00:06<00:00, 13.88it/s]
Test: target_loss: 1.322 prec_loss: 0.044 concepts_loss: 9.477 total_loss: 10.843 y_accuracy: 0.713 c_accuracy: 0.950 complete_c_accuracy: 0.454 target_jaccard: 0.554 concept_jaccard: 0.770 y_AUROC: 0.988 y_AUPR: 0.762 y_Brier: 0.412 y_ECE: 0.081 y_TL-ECE: 0.087 c_AUROC: 0.977 c_AUPR: 0.919 c_Brier: 0.038 c_ECE: 0.023 c_TL-ECE: 0.051


real    15m44.741s
user    122m43.100s
sys     12m32.141s

